### PR TITLE
add title and description options to pr create

### DIFF
--- a/bb/pr/__init__.py
+++ b/bb/pr/__init__.py
@@ -52,7 +52,8 @@ def create(
     rebase: bool = typer.Option(
         False, help="rebase source branch with target before creation"
     ),
-    description: str = typer.Option("", help="PR description message"),
+    title: str = typer.Option("", help="PR title"),
+    description: str = typer.Option("", help="PR description"),
 ) -> None:
     """
     Takes in parameters for target branch name, a confirmation flag, diff
@@ -71,7 +72,9 @@ def create(
     -   :param rebase: A  boolean option that determines  whether the source branch should be
         rebased with the target branch before creating the pull request.
         :type rebase: bool
-    -   :param description: Optional 'title:description' for the pr. If not provided, the last commit message will be used
+    -   :param title: Optional title for the pr. If not provided, the last commit message will be used
+        :type title: str
+    -   :param description: Optional description for the pr. If not provided, the last commit message will be used
         :type description: str
     Raises:
     -   ValueError: If the repository is not a Git repository
@@ -85,7 +88,7 @@ def create(
 
     target = validate_input(target, "Target branch", "Target branch cannot be none")
 
-    create_pull_request(target, yes, diff, rebase, description)
+    create_pull_request(target, yes, diff, rebase, title, description)
 
 
 @_pr.command(help="Delete pull requests")

--- a/bb/pr/__init__.py
+++ b/bb/pr/__init__.py
@@ -52,6 +52,7 @@ def create(
     rebase: bool = typer.Option(
         False, help="rebase source branch with target before creation"
     ),
+    description: str = typer.Option("", help="PR description message"),
 ) -> None:
     """
     Takes in parameters for target branch name, a confirmation flag, diff
@@ -70,6 +71,8 @@ def create(
     -   :param rebase: A  boolean option that determines  whether the source branch should be
         rebased with the target branch before creating the pull request.
         :type rebase: bool
+    -   :param description: Optional 'title:description' for the pr. If not provided, the last commit message will be used
+        :type description: str
     Raises:
     -   ValueError: If the repository is not a Git repository
     -   ValueError: If the target branch is not provided
@@ -82,7 +85,7 @@ def create(
 
     target = validate_input(target, "Target branch", "Target branch cannot be none")
 
-    create_pull_request(target, yes, diff, rebase)
+    create_pull_request(target, yes, diff, rebase, description)
 
 
 @_pr.command(help="Delete pull requests")

--- a/bb/pr/create.py
+++ b/bb/pr/create.py
@@ -25,7 +25,6 @@ while doing so it gathers all the facts required for a pr from the
 remote and local repository
 """
 
-import re
 from typing import Optional
 
 from typer import confirm

--- a/bb/pr/create.py
+++ b/bb/pr/create.py
@@ -120,11 +120,7 @@ def create_pull_request(target: str, yes: bool, diff: bool, rebase: bool, title:
             cmnd.git_rebase(target)
             live.update(richprint.console.print("REBASED", style="bold green"))
 
-    defaultTitleAndDescription = cmnd.title_and_description()
-    if len(title) == 0:
-        title = defaultTitleAndDescription[0]
-    if len(description) == 0:
-        description = defaultTitleAndDescription[1]
+    title, description = title or cmnd.title_and_description()[0], description or cmnd.title_and_description()[1]
 
     project, repository = cmnd.base_repo()
     

--- a/bb/pr/create.py
+++ b/bb/pr/create.py
@@ -25,6 +25,7 @@ while doing so it gathers all the facts required for a pr from the
 remote and local repository
 """
 
+import re
 from typing import Optional
 
 from typer import confirm
@@ -32,7 +33,6 @@ from typer import confirm
 from bb.pr.diff import show_diff
 from bb.utils import cmnd, request, richprint
 from bb.utils.api import bitbucket_api
-import re
 
 def gather_facts(
     target: str,

--- a/bb/pr/create.py
+++ b/bb/pr/create.py
@@ -33,6 +33,7 @@ from bb.pr.diff import show_diff
 from bb.utils import cmnd, request, richprint
 from bb.utils.api import bitbucket_api
 
+
 def gather_facts(
     target: str,
     from_branch: str,
@@ -123,7 +124,7 @@ def create_pull_request(target: str, yes: bool, diff: bool, rebase: bool, title:
     title, description = title or cmnd.title_and_description()[0], description or cmnd.title_and_description()[1]
 
     project, repository = cmnd.base_repo()
-    
+
     reviewers = gather_facts(
         target,
         from_branch,

--- a/bb/pr/create.py
+++ b/bb/pr/create.py
@@ -39,7 +39,8 @@ def gather_facts(
     from_branch: str,
     project: str,
     repository: str,
-    title_and_description: str,
+    title: str,
+    description: str,
 ) -> list:
     """
     It gathers facts for  the pull request from bitbucket and local git
@@ -50,7 +51,8 @@ def gather_facts(
     -   from_branch: str: The source branch
     -   project: str: The project name
     -   repository: str: The repository name
-    -   title_and_description: str: The title and description for the pull request
+    -   title: str: The title for the pull request
+    -   description: str: The description for the pull request
     Returns:
     -   list: The list of reviewers
     Raises:
@@ -81,8 +83,8 @@ def gather_facts(
             ("Repository ID", str(repo_id)),
             ("From Branch", from_branch),
             ("To Branch", target),
-            ("Title", title_and_description[0]),
-            ("Description", title_and_description[1]),
+            ("Title", title),
+            ("Description", description),
         ],
         True,
     )
@@ -90,7 +92,7 @@ def gather_facts(
     return reviewers
 
 
-def create_pull_request(target: str, yes: bool, diff: bool, rebase: bool, description: str) -> None:
+def create_pull_request(target: str, yes: bool, diff: bool, rebase: bool, title: str, description: str) -> None:
     """
     Handles the process of creating a pull request with  options for rebasing,
     confirmation prompts, and displaying the diff.
@@ -100,7 +102,8 @@ def create_pull_request(target: str, yes: bool, diff: bool, rebase: bool, descri
     -   yes: bool: The flag to proceed without confirmation
     -   diff: bool: The flag to display the diff
     -   rebase: bool: The flag to rebase the source branch with the target branch
-    -   description: str: Optional 'title:description' for the pull request. If not provided, it will be taken from the commit message
+    -   title: str: Optional title for the pull request. If not provided, it will be taken from the commit message
+    -   description: str: Optional description for the pull request. If not provided, it will be taken from the commit message
     Raises:
     -   ValueError: If the source and target branches are the same
     Returns:
@@ -118,11 +121,11 @@ def create_pull_request(target: str, yes: bool, diff: bool, rebase: bool, descri
             cmnd.git_rebase(target)
             live.update(richprint.console.print("REBASED", style="bold green"))
 
-
-    if re.match(r".*:.*", description):
-        title_and_description = [description.split(":")[0], description.split(":")[1]]
-    else:
-        title_and_description = cmnd.title_and_description()
+    defaultTitleAndDescription = cmnd.title_and_description()
+    if len(title) == 0:
+        title = defaultTitleAndDescription[0]
+    if len(description) == 0:
+        description = defaultTitleAndDescription[1]
 
     project, repository = cmnd.base_repo()
     
@@ -131,14 +134,16 @@ def create_pull_request(target: str, yes: bool, diff: bool, rebase: bool, descri
         from_branch,
         project,
         repository,
-        title_and_description,
+        title,
+        description
     )
 
     if yes or confirm("Proceed"):
         with richprint.live_progress("Creating Pull Request ..."):
             url = bitbucket_api.pull_request_create(project, repository)
             body = bitbucket_api.pull_request_body(
-                title_and_description,
+                title,
+                description,
                 from_branch,
                 repository,
                 project,

--- a/bb/utils/api.py
+++ b/bb/utils/api.py
@@ -111,7 +111,8 @@ class BitbucketAPI:
 
     def pull_request_body(
         self,
-        title_and_description: str,
+        title: str,
+        description: str,
         from_branch: str,
         repository: str,
         project: str,
@@ -122,7 +123,8 @@ class BitbucketAPI:
         Generate the JSON body for creating a pull request.
 
         Args:
-            title_and_description (str): The title and description of the pull request.
+            title (str): The title of the pull request.
+            description (str): The description of the pull request.
             from_branch (str): The source branch of the pull request.
             repository (str): The name of the repository.
             project (str): The key of the project.
@@ -134,8 +136,8 @@ class BitbucketAPI:
         """
         return json.dumps(
             {
-                "title": title_and_description[0],
-                "description": title_and_description[1],
+                "title": title,
+                "description": description,
                 "state": "OPEN",
                 "open": "true",
                 "closed": "false",


### PR DESCRIPTION
A new optional parameter called "description" that allows passing title and description in format "title:description". If not passed, the default mechanism of using last commit message kicks in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced optional `title` and `description` parameters for creating pull requests, allowing users to provide custom titles and descriptions for better clarity and usability.
	- Enhanced flexibility in the pull request creation process by validating and utilizing separate title and description inputs.

- **Documentation**
	- Updated documentation to reflect the new parameters and their usage in the pull request creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->