### PR TITLE
feat(bb:pr:create): Ability to override PR Title and Description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,4 @@ package*.json
 .DS_Store
 .pdm.toml
 .pdm-python
+test

--- a/bb/pr/__init__.py
+++ b/bb/pr/__init__.py
@@ -36,7 +36,7 @@ from bb.pr.list import list_pull_request
 from bb.pr.merge import merge_pull_request
 from bb.pr.review import review_pull_request
 from bb.pr.view import view_pull_request
-from bb.utils.cmnd import is_git_repo
+from bb.utils.cmnd import is_git_repo, title_and_description
 from bb.utils.constants import common_vars
 from bb.utils.helper import error_handler, validate_input
 
@@ -52,6 +52,8 @@ def create(
     rebase: bool = typer.Option(
         False, help="rebase source branch with target before creation"
     ),
+    title: str = typer.Option("", help="pull request title"),
+    description: str = typer.Option("", help="pull request description"),
 ) -> None:
     """
     Takes in parameters for target branch name, a confirmation flag, diff
@@ -82,7 +84,18 @@ def create(
 
     target = validate_input(target, "Target branch", "Target branch cannot be none")
 
-    create_pull_request(target, yes, diff, rebase)
+    title = validate_input(
+        title, "Title", "", title if title else title_and_description()[0], True
+    )
+    description = validate_input(
+        description,
+        "Description",
+        "",
+        description if description else title_and_description()[1],
+        True,
+    )
+
+    create_pull_request(target, yes, diff, rebase, title, description)
 
 
 @_pr.command(help="Delete pull requests")
@@ -199,7 +212,7 @@ def review(
     action: str = validate_input(
         action_value,
         "Action [approve|unapprove|needs_work]",
-        "action cannot be none",
+        "'--action' is a mandatory argument, run 'bb pr review --help' for more info",
     )
     review_pull_request(_id, action)
 

--- a/bb/utils/api.py
+++ b/bb/utils/api.py
@@ -111,7 +111,8 @@ class BitbucketAPI:
 
     def pull_request_body(
         self,
-        title_and_description: str,
+        title: str,
+        description: str,
         from_branch: str,
         repository: str,
         project: str,
@@ -122,7 +123,8 @@ class BitbucketAPI:
         Generate the JSON body for creating a pull request.
 
         Args:
-            title_and_description (str): The title and description of the pull request.
+            title (str): The title of the pull request.
+            description (str): The description of the pull request.
             from_branch (str): The source branch of the pull request.
             repository (str): The name of the repository.
             project (str): The key of the project.
@@ -134,8 +136,8 @@ class BitbucketAPI:
         """
         return json.dumps(
             {
-                "title": title_and_description[0],
-                "description": title_and_description[1],
+                "title": title,
+                "description": description,
                 "state": "OPEN",
                 "open": "true",
                 "closed": "false",

--- a/bb/utils/helper.py
+++ b/bb/utils/helper.py
@@ -56,7 +56,9 @@ def validate_config() -> None:
         raise ValueError(err) from err
 
 
-def validate_input(_input: Any, expected: str, error: str) -> str:
+def validate_input(
+    _input: Any, expected: str, error: str, default: str = "", optional: bool = False
+) -> str:
     """
     Validates the input value based on the expected type and error message.
 
@@ -72,17 +74,32 @@ def validate_input(_input: Any, expected: str, error: str) -> str:
         str: The validated input value.
     """
 
+    check = 0
+
     def checker():
         if not isinstance(_input, (str)):
             raise ValueError(error)
 
-        if _input is None or _input.lower() == "none":
+        if (
+            _input is None
+            or _input.lower() == "none"
+            or _input == ""
+            and check == 1
+            and not optional
+        ):
             raise ValueError(error)
 
     checker()
 
     if not _input:
-        _input: str = prompt(f"? {expected}")
+        _input: str = prompt(
+            f"? {expected}",
+            default=default,
+            show_default=default != "",
+        )
+
+        check += 1
+
         checker()
 
     return _input

--- a/bb/utils/richprint.py
+++ b/bb/utils/richprint.py
@@ -50,9 +50,9 @@ def str_print(text: str, style: str) -> None:
     Returns:
         None
     """
-    _text = Text(text)
-    _text.stylize(style)
-    console.print(_text)
+    text = Text(text)
+    text.stylize(style)
+    console.print(text)
 
 
 def table(header_args: list, value_args: list, show_header: bool) -> Table:

--- a/pdm.lock
+++ b/pdm.lock
@@ -416,7 +416,7 @@ files = [
 
 [[package]]
 name = "pre-commit"
-version = "3.7.1"
+version = "3.8.0"
 requires_python = ">=3.9"
 summary = "A framework for managing and maintaining multi-language pre-commit hooks."
 groups = ["dev"]
@@ -428,8 +428,8 @@ dependencies = [
     "virtualenv>=20.10.0",
 ]
 files = [
-    {file = "pre_commit-3.7.1-py2.py3-none-any.whl", hash = "sha256:fae36fd1d7ad7d6a5a1c0b0d5adb2ed1a3bda5a21bf6c3e5372073d7a11cd4c5"},
-    {file = "pre_commit-3.7.1.tar.gz", hash = "sha256:8ca3ad567bc78a4972a3f1a477e94a79d4597e8140a6e0b651c5e33899c3654a"},
+    {file = "pre_commit-3.8.0-py2.py3-none-any.whl", hash = "sha256:9a90a53bf82fdd8778d58085faf8d83df56e40dfe18f45b19446e26bf1b3a63f"},
+    {file = "pre_commit-3.8.0.tar.gz", hash = "sha256:8bb6494d4a20423842e198980c9ecf9f96607a07ea29549e180eef9ae80fe7af"},
 ]
 
 [[package]]

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ packaging==24.1
 pbr==6.0.0
 platformdirs==4.2.2
 pluggy==1.5.0
-pre-commit==3.7.1
+pre-commit==3.8.0
 pygments==2.18.0
 pyproject-api==1.7.1
 pytest==8.3.2

--- a/tests/props.py
+++ b/tests/props.py
@@ -30,12 +30,8 @@ class Api:
     repo_id: str = "1234"
     from_branch: str = "feature/test_branch"
     target: str = "master"
-    title_and_description: list[str, str] = field(
-        default_factory=lambda: [
-            "pull request title",
-            "pull request description",
-        ]
-    )
+    title: str = "pull request title"
+    description: str = "pull request description"
     reviewers: list[str] = field(default_factory=lambda: ["test"])
     pr_no: int = 1
     role: str = "author"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -81,7 +81,8 @@ def test_default_reviewers():
 
 def test_pull_request_body():
     pull_request_body = bitbucket_api.pull_request_body(
-        property.title_and_description,
+        property.title,
+        property.description,
         property.from_branch,
         property.repository,
         property.project,
@@ -91,8 +92,8 @@ def test_pull_request_body():
 
     assert pull_request_body == json.dumps(
         {
-            "title": property.title_and_description[0],
-            "description": property.title_and_description[1],
+            "title": property.title,
+            "description": property.description,
             "state": "OPEN",
             "open": "true",
             "closed": "false",


### PR DESCRIPTION
Default PR Title & Description can be overridden as part PR creation, if empty defaults to existing values from the commit header and body


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added optional parameters for custom title and description when creating pull requests, enhancing contextual clarity.
- **Bug Fixes**
	- Improved usability by separating title and description inputs in multiple functions, reducing potential confusion.
- **Chores**
	- Updated documentation to reflect changes in function parameters and improve clarity for users.
	- Upgraded the `pre-commit` package version to enhance the development workflow.
	- Added a `.gitignore` entry to ignore test-related files and directories for a cleaner repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->